### PR TITLE
rust: add simple CLI tool

### DIFF
--- a/ringsig/Cargo.lock
+++ b/ringsig/Cargo.lock
@@ -59,6 +59,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,6 +121,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin_hashes",
  "curve25519-dalek",
+ "home",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -204,6 +214,28 @@ name = "wasm-bindgen-shared"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "zeroize"

--- a/ringsig/Cargo.toml
+++ b/ringsig/Cargo.toml
@@ -8,11 +8,16 @@ name = "ringsig"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"]
 
+[[bin]]
+name = "ringsig-cli"
+path = "src/ringsig-cli.rs"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 curve25519-dalek = { version = "3", default-features = false, features = [ "u64_backend" ] }
 bitcoin_hashes = { version = "0.11", default-features = false, features = [ "std" ] }
+home = "0.5"
 wasm-bindgen = "0.2"
 js-sys = "0.3"
 

--- a/ringsig/src/lib.rs
+++ b/ringsig/src/lib.rs
@@ -43,6 +43,10 @@ fn hash_to_sc<T: Hash<Inner = [u8; 32]>>(inp: T) -> Scalar {
 }
 
 pub fn verify(proof: &[u8], pks: &[PublicKey], message: &[u8]) -> Result<(), &'static str> {
+    if pks.is_empty() {
+        return Err("no public keys");
+    }
+
     if proof.len() != 32 * (pks.len() + 1) {
         return Err("proof wrong length");
     }
@@ -136,6 +140,12 @@ mod tests {
         let pk = sk1.to_public();
         let proof = prove(&[pk], b"Hello, world!", sk1).unwrap();
         verify(&proof, &[pk], b"Hello, world!").unwrap();
+        assert!(verify(&proof, &[pk], b"Goodbye, world!").is_err());
+    }
+
+    #[test]
+    fn empty_proof() {
+        let proof = b"32 bytes32 bytes32 bytes32 bytes";
         assert!(verify(&proof, &[pk], b"Goodbye, world!").is_err());
     }
 

--- a/ringsig/src/lib.rs
+++ b/ringsig/src/lib.rs
@@ -42,7 +42,7 @@ fn hash_to_sc<T: Hash<Inner = [u8; 32]>>(inp: T) -> Scalar {
     Scalar::from_bits(inp.into_inner())
 }
 
-fn verify(proof: &[u8], pks: &[PublicKey], message: &[u8]) -> Result<(), &'static str> {
+pub fn verify(proof: &[u8], pks: &[PublicKey], message: &[u8]) -> Result<(), &'static str> {
     if proof.len() != 32 * (pks.len() + 1) {
         return Err("proof wrong length");
     }
@@ -64,7 +64,7 @@ fn verify(proof: &[u8], pks: &[PublicKey], message: &[u8]) -> Result<(), &'stati
     Ok(())
 }
 
-fn prove(pks: &[PublicKey], message: &[u8], sk: SecretKey) -> Result<Vec<u8>, &'static str> {
+pub fn prove(pks: &[PublicKey], message: &[u8], sk: SecretKey) -> Result<Vec<u8>, &'static str> {
     let params = param_hash(pks, message);
     let my_pk = sk.to_public();
     let my_idx = match pks.iter().position(|&pk| pk == my_pk) {

--- a/ringsig/src/ringsig-cli.rs
+++ b/ringsig/src/ringsig-cli.rs
@@ -1,0 +1,118 @@
+// Crypto Confessions
+// Written in 2022 by
+//   Andrew Poelstra <cryptoconfessions@wpsoftware.net>
+//   or David Vorick <cryptoconfessions@wpsoftware.net>
+//   or Liam Eagen <cryptoconfessions@wpsoftware.net>
+//
+// To the extent possible under law, the author(s) have dedicated all
+// copyright and related and neighboring rights to this software to
+// the public domain worldwide. This software is distributed without
+// any warranty.
+//
+// You should have received a copy of the CC0 Public Domain Dedication
+// along with this software.
+// If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+//
+
+use bitcoin_hashes::hex::{FromHex, ToHex};
+use home::home_dir;
+use ringsig::armor::FromArmor;
+use ringsig::keys::{PublicKey, SecretKey};
+use std::{env, fs, io};
+use std::io::{BufRead, Read};
+
+fn usage() -> Result<(), &'static str> {
+    let name = env::args().next().unwrap();
+    eprintln!("Usage: {} prove <public key list> [secret key file]", name);
+    eprintln!("Usage: {} verify <public key list> <proof>", name);
+    eprintln!("");
+    eprintln!("Here <public key list> should refer to a text file containing a list of");
+    eprintln!("public keys, in the .ssh/authorized_keys format, one on each line.");
+    eprintln!("public keys, in the .ssh/authorized_keys format, one on each line.");
+    eprintln!("");
+    eprintln!("If <secret key file> is provided this will be used as the signing key.");
+    eprintln!("Otherwise, the tool will just try to use every file in ~/.ssh as a key.");
+    eprintln!("");
+    eprintln!("<proof> is a hex-encoded proof");
+    eprintln!("");
+    eprintln!("The message to sign is then provided on standard input. Use < to read");
+    eprintln!("from a file instead.");
+    Err("invalid-command-line-args")
+}
+
+fn main() -> Result<(), String> {
+    let args: Vec<_> = env::args().collect();
+    if args.len() < 2 {
+        usage()?;
+    }
+    match &args[1][..] {
+        "prove" if args.len() == 3 || args.len() == 4 => {},
+        "verify" if args.len() == 4 => {},
+        _ => usage()?,
+    }
+
+    // Obtain list of public keys
+    let keyfile = fs::File::open(&args[2])
+        .map(io::BufReader::new)
+        .map_err(|e| e.to_string())?;
+    let keys = keyfile
+        .lines()
+        .map(|result| result.map(|ln| PublicKey::parse_pk_line(&ln)))
+        .filter_map(|result| match result {
+            Ok(Ok(ok)) => Some(Ok(ok)),
+            Ok(Err(ringsig::keys::Error::EmptyKey)) => None, // blank lines ok
+            Ok(Err(e)) => Some(Err(format!("Parsing public keys from {}: {:?}", args[1], e))), // FIXME
+            Err(e) => Some(Err(e.to_string())),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Obtain secret key for proving
+    if args[1] == "prove" {
+        let sk;
+        if args.len() == 4 {
+            let sk_str = fs::read_to_string(&args[3]).map_err(|e| e.to_string())?;
+            sk = SecretKey::from_armor(&sk_str)
+                .map_err(|e| format!("Reading secret key file {}: {:?}", args[3], e))?; // FIXME
+        } else {
+            let mut try_sk = None;
+            let mut ssh_dir = match home_dir() {
+                Some(homedir) => homedir,
+                None => return Err("Unknown home directory. Please specify a secret key file on the command line.".into()),
+            };
+            ssh_dir.push(".ssh");
+            for file in fs::read_dir(ssh_dir).map_err(|e| e.to_string())? {
+                let file = file.map_err(|e| e.to_string())?;
+                let sk_str = fs::read_to_string(file.path()).map_err(|e| e.to_string())?;
+                try_sk = SecretKey::from_armor(&sk_str).ok();
+                if try_sk.is_some() { break }
+            }
+            match try_sk {
+                Some(found_sk) => sk = found_sk,
+                None => return Err("no-sk-found".into()),
+            }
+        }
+
+        // Obtain message
+        let mut msg = vec![];
+        io::stdin().read_to_end(&mut msg).map_err(|e| e.to_string())?;
+
+        // Do the proof
+        let proof = ringsig::prove(&keys, &msg, sk)?;
+        println!("{}", proof.to_hex());
+    }
+
+    // Obtain proof for verifying
+    if args[1] == "verify" {
+        let proof = Vec::<u8>::from_hex(&args[3])
+            .map_err(|e| e.to_string())?;
+
+        // Obtain message
+        let mut msg = vec![];
+        io::stdin().read_to_end(&mut msg).map_err(|e| e.to_string())?;
+
+        ringsig::verify(&proof, &keys, &msg)?;
+    }
+
+    Ok(())
+}
+


### PR DESCRIPTION
Need to go over all the error handling, fix the library error types,
use 'anyhow' to provide context, etc., but that's for another time .

Also need to clean up argument handling, probably with 'clap', at
the very least to allow the user to provide a (potentially huge)
proof as a file rather than inlne.