### PR TITLE
rust: allow keys that have other ssh-ed25519 prefixes

### DIFF
--- a/ringsig/src/keys.rs
+++ b/ringsig/src/keys.rs
@@ -90,7 +90,8 @@ impl PublicKey {
         if pieces.is_empty() {
             return Err(Error::EmptyKey);
         }
-        if pieces[0] != "ssh-ed25519" {
+        // There are several allowable prefixes, all of which have ed25519 in them, according to the ssh source
+        if !pieces[0].contains("ssh-ed25519") {
             return Err(Error::WrongKeyType { expected: "ssh-ed25519".to_string(), got: pieces[0].to_string() });
         }
         if pieces.len() < 2 {

--- a/ringsig/testdata/test-prove.json
+++ b/ringsig/testdata/test-prove.json
@@ -3,7 +3,8 @@
   "publicKeys" : [
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAyxLYuvSF14BJXejP+Qx6yLH1MXr/HGOcLZU55TodKS",
     "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKHQ634LrVRQ0bLDLZ5kdjcpmihQBtcJbGoMqCJh6i10",
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDdtluGSY0vvzgcdU3GTIfWtrr8KMSk8Y1i9NJfRCkV1 apoelstra@sultana"
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDdtluGSY0vvzgcdU3GTIfWtrr8KMSk8Y1i9NJfRCkV1 apoelstra@sultana",
+    "sk-ssh-ed25519@openssh.com AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAIJMjTxa8PYNncRTEuBM8v+CzmuZ1gWEwScL6jWZn2Dz6AAAABHNzaDo="
   ],
   "message" : "this is an example text"
 }


### PR DESCRIPTION
Some keys on github have weird prefixes and ssh.c confirms that a specific ad-hoc list is ok.